### PR TITLE
add: getLastAuthorizerAccessToken function

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,36 @@ var saveComponentToken = function(token, callback) {
   });
 };
 
-var wxauth = new WXAuth(appid, appsecret, getVerifyTicket, getComponentToken, saveComponentToken);
+/*
+ * 获取全局authorizer_access_token的方法
+ * 从redis缓存中读取
+ */
+var getAuthorizerAccessToken = function(appid, callback) {
+  return redisClient.get(`authorizer_access_token:${appid}`, function(err, accessToken) {
+    if (err) {
+      return callback(err)
+    } else {
+      return callback(null, JSON.parse(accessToken));
+    }
+  });
+};
+
+/*
+ * 设置全局authorizer_access_token的方法
+ * 从redis缓存中读取
+ */
+var saveAuthorizerAccessToken = function(appid, accessToken, callback) {
+  let key = `authorizer_access_token:${appid}`
+  return redisClient.setex(key, 7000, JSON.stringify(accessToken), function(err, reply) {
+    if (err) {
+      return callback(err)
+    } else {
+      return callback(null, reply);
+    }
+  });
+};
+
+var wxauth = new WXAuth(appid, appsecret, getVerifyTicket, getComponentToken, saveComponentToken, getAuthorizerAccessToken, saveAuthorizerAccessToken);
 ```
 
 ### 获取第三方平台component_access_token

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -15,7 +15,7 @@ var ComponentAccessToken = function (data) {
  * 检查ComponentAccessToken是否有效
  */
 ComponentAccessToken.prototype.isValid = function () {
-  return !!this.component_comaccess_token && (new Date().getTime()) < this.expires_at;
+  return !!this.component_access_token && (new Date().getTime()) < this.expires_at;
 };
 
 var AuthorizerAccessToken = function (data) {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -11,7 +11,6 @@ var ComponentAccessToken = function (data) {
   this.expires_at = data.expires_at;
 };
 
-
 /**
  * 检查ComponentAccessToken是否有效
  */
@@ -19,6 +18,21 @@ ComponentAccessToken.prototype.isValid = function () {
   return !!this.component_comaccess_token && (new Date().getTime()) < this.expires_at;
 };
 
+var AuthorizerAccessToken = function (data) {
+  if (!(this instanceof AuthorizerAccessToken)) {
+    return new AuthorizerAccessToken(data);
+  }
+  this.expires_at = data.expires_at;
+  this.authorizer_refresh_token = data.authorizer_refresh_token;
+  this.authorizer_access_token = data.authorizer_access_token;
+};
+
+/**
+ * 检查AuthToken是否有效
+ */
+AuthorizerAccessToken.prototype.isValid = function () {
+  return !!this.authorizer_access_token && (new Date().getTime()) < this.expires_at;
+};
 
 /**
  * 根据appid和appsecret创建Auth的构造函数
@@ -28,20 +42,32 @@ ComponentAccessToken.prototype.isValid = function () {
  * @param {Function} getComponentToken 获取全局component_access_token的方法，选填项，多进程状态下应该存放在缓存中
  * @param {Function} saveComponentToken获取全局component_access_token的方法，选填项，多进程状态下应该存放在缓存中
  */
-var Auth = function (appid, appsecret, getVerifyTicket, getComponentToken, saveComponentToken) {
+var Auth = function (appid, appsecret, getVerifyTicket, getComponentToken, saveComponentToken, getAuthorizerAccessToken, saveAuthorizerAccessToken) {
   this.appid = appid;
   this.appsecret = appsecret;
   this.getVerifyTicket = getVerifyTicket;
+  // 缓存AuthorizerAccessToken
+  this.authToken = {};
   this.getComponentToken = getComponentToken || function (callback) {
-    callback(null, this.store);
-  };
+      callback(null, this.store);
+    };
   this.saveComponentToken = saveComponentToken || function (token, callback) {
-    this.store = token;
-    if (process.env.NODE_ENV === 'production') {
-      console.warn('Don\'t save token in memory, when cluster or multi-computer!');
+      this.store = token;
+      if (process.env.NODE_ENV === 'production') {
+        console.warn('Don\'t save token in memory, when cluster or multi-computer!');
+      }
+      callback(null);
+    };
+  this.getAuthorizerAccessToken = getAuthorizerAccessToken || function (appid, callback) {
+      callback(null, this.authToken[appid]);
     }
-    callback(null);
-  };
+  this.saveAuthorizerAccessToken = saveAuthorizerAccessToken || function (appid, authToken, callback) {
+      this.authToken[appid] = authToken;
+      if (process.env.NODE_ENV === 'production') {
+        console.warn('Don\'t save authToken in memory, when cluster or multi-computer!');
+      }
+      callback(null);
+    };
   this.prefix = 'https://api.weixin.qq.com/cgi-bin/component/';
   this.snsPrefix = 'https://api.weixin.qq.com/sns/';
 };
@@ -109,7 +135,7 @@ Auth.prototype.getComponentAccessToken = function (callback) {
       token.expires_at = expireTime;
       that.saveComponentToken(token, function (err) {
         if (err) {
-          return callback(err); 
+          return callback(err);
         }
         callback(err, token);
       });
@@ -206,10 +232,44 @@ Auth.prototype.getLatestComponentToken = function (callback) {
   });
 };
 
+/*
+ * 获取最新的authorizer_access_token
+ * 该接口用于开发者调用第三方公众号的接口
+ * 官方文档: https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1453779503&token=3a33f64b717bdca61655ef6cb6021d83dcad81a3&lang=zh_CN
+ * Examples:
+ * ```
+ * auth.getLastAuthorizerAccessToken(authorizerAppid,callback);
+ * ```
+ * callback:
+ *
+ * - `err`, 出现异常时的异常对象
+ * - `token`, 获取的authorizer_access_token
+ *
+ * @param {Function} callback 回调函数
+ */
+Auth.prototype.getLastAuthorizerAccessToken = function (authorizerAppid, callback) {
+  var that = this;
+  // 调用用户传入的获取token的异步方法，获得token之后使用（并缓存它）。
+  this.getAuthorizerAccessToken(authorizerAppid, function (err, token) {
+    if (err) {
+      return callback(err);
+    }
+    var authorizerAccessToken;
+    if (token && (authorizerAccessToken = AuthorizerAccessToken(token)).isValid()) {
+      callback(null, token);
+    } else if (token && token.authorizer_refresh_token) {
+      // 使用appid/appsecret获取token
+      that.refreshAuthToken(authorizerAppid, token.authorizer_refresh_token, callback);
+    } else {
+      callback('lose authorizer_refresh_token')
+    }
+  });
+};
+
 
 /*
  * 获取预授权码pre_auth_code
- * 
+ *
  * Result:
  * ```
  * {"pre_auth_code": "PRE_AUTH_CODE", "expires_in": 600}
@@ -270,6 +330,7 @@ Auth.prototype.getAuthToken = function(auth_code, callback) {
  * 获取授权信息的未封装版本
  */
 Auth.prototype._getAuthToken = function(auth_code, callback) {
+  var that = this;
   var url = this.prefix + 'api_query_auth?component_access_token=' + this.token.component_access_token;
   var params = {
     component_appid: this.appid,
@@ -281,7 +342,25 @@ Auth.prototype._getAuthToken = function(auth_code, callback) {
     dataType: 'json',
     contentType: 'json'
   };
-  this.request(url, args, wrapper(callback));
+  this.request(url, args, wrapper(function(err, authorization) {
+    if (err) {
+      return callback(err);
+    }
+
+    // 过期时间，因网络延迟等，将实际过期时间提前100秒
+    var expireTime = (new Date().getTime()) + (authorization.authorization_info.expires_in - 100) * 1000;
+    let authorization_access_token = {
+      authorizer_access_token: authorization.authorization_info.authorizer_access_token,
+      expires_at: expireTime,
+      authorizer_refresh_token: authorization.authorization_info.authorizer_refresh_token
+    }
+    that.saveAuthorizerAccessToken(authorization.authorization_info.authorizer_appid, authorization_access_token, function (err) {
+      if (err) {
+        return callback(err);
+      }
+      callback(err, authorization);
+    });
+  }));
 };
 
 
@@ -303,13 +382,14 @@ Auth.prototype._getAuthToken = function(auth_code, callback) {
  * @param {Function} callback 回调函数
  */
 Auth.prototype.refreshAuthToken = function(authorizer_appid, authorizer_refresh_token, callback) {
-  this.preRequest(this._refreshAuthToken, arguments); 
+  this.preRequest(this._refreshAuthToken, arguments);
 };
 
 /*!
  * 未封装的刷新接口调用凭据接口
  */
 Auth.prototype._refreshAuthToken = function(authorizer_appid, authorizer_refresh_token, callback) {
+  var that = this
   var url = this.prefix + 'api_authorizer_token?component_access_token=' + this.token.component_access_token;
   var params = {
     component_appid: this.appid,
@@ -322,7 +402,20 @@ Auth.prototype._refreshAuthToken = function(authorizer_appid, authorizer_refresh
     dataType: 'json',
     contentType: 'json'
   };
-  this.request(url, args, wrapper(callback));
+  this.request(url, args, wrapper(function(err, token) {
+    if (err) {
+      return callback(err);
+    }
+    // 过期时间，因网络延迟等，将实际过期时间提前100秒
+    var expireTime = (new Date().getTime()) + (token.expires_in - 100) * 1000;
+    token.expires_at = expireTime;
+    that.saveAuthorizerAccessToken(authorizer_appid, token, function (err) {
+      if (err) {
+        return callback(err);
+      }
+      callback(err, token);
+    });
+  }));
 };
 
 
@@ -529,6 +622,6 @@ Auth.prototype.getUserInfo = function (openid, access_token, lang, callback) {
   };
   this.request(url, args, wrapper(callback));
 };
- 
+
 
 module.exports = Auth;


### PR DESCRIPTION
新增获取最新的授权公众号的accessToken函数，原有的`refreshAuthToken`函数没有做缓存accessToken会出现接口调用次数超限。
[官方文档：](https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1453779503&token=&lang=zh_CN)

```
5、获取（刷新）授权公众号的接口调用凭据（令牌）
该API用于在授权方令牌（authorizer_access_token）失效时，可用刷新令牌（authorizer_refresh_token）获取新的令牌。请注意，此处token是2小时刷新一次，开发者需要自行进行token的缓存，避免token的获取次数达到每日的限定额度。缓存方法可以参考：http://mp.weixin.qq.com/wiki/2/88b2bf1265a707c031e51f26ca5e6512.html
```
